### PR TITLE
minor bugfix to rename_clusters

### DIFF
--- a/R/convenience_fxns.R
+++ b/R/convenience_fxns.R
@@ -14,7 +14,7 @@
 #' @export 
 #' 
 rename_clusters = function(dom, clust_conv){
-    if(is.null(clusters)){
+    if(is.null(dom@clusters)){
         stop("There are no clusters in this domino object")
     }
     if(dom@misc$create){


### PR DESCRIPTION
calling the cluster assignmen vector did not include that the vector was nested within the "dom" domino object that the rename_clusters() function was acting upon.