### PR TITLE
Jtm/plotting/circos plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports:
     plyr,
     dplyr,
     igraph,
+    circlize
 License: GPL-3 | file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
     plyr,
     dplyr,
     igraph,
-    circlize
+    circlize,
+    ComplexHeatmap
 License: GPL-3 | file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -776,8 +776,8 @@ circos_ligand_receptor <-
   )
   lgd_list_vertical = packLegend(lgd_cells, lgd_ligands)
   draw(lgd_list_vertical, 
-       x = unit(1, "npc"), y = unit(0.5, "npc"),
-       just = c("right", "center"))
+       x = unit(0.02, "npc"), y = unit(0.98, "npc"),
+       just = c("left", "top"))
 }
 
 #' Normalize a matrix to its max value by row or column

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -644,8 +644,7 @@ circos_ligand_receptor <-
     # cell_colors: named vector of colors for plotted cell types. Defaults to scales::hue_pal()
     # ident_names: TODO debug argument to allow passing of [cell_ident] with \n to make long names more legible on the circos plot
     
-    # TODO: Add circlize to package dependencies
-    library(circlize)
+    require(circlize)
     
     z_scores <- dom@z_scores
     ligands <- dom@linkages$rec_lig[[receptor]]
@@ -702,8 +701,6 @@ circos_ligand_receptor <-
       ) 
     names(grid_col) <- c(receptor, signaling_df$origin)
     # initiate pdf plotting device
-    pdf(file = file,
-        width = 14, height = 12)
     circos.clear()
     circos.par(start.degree = 0)
     
@@ -759,8 +756,6 @@ circos_ligand_receptor <-
       text.col = "black", niceFacing = TRUE,
       pos = 4
     )
-    
-    dev.off()
   }
 
 #' Normalize a matrix to its max value by row or column

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -735,17 +735,11 @@ circos_ligand_receptor <-
     for(cell in cell_sectors){
       row_pick <- sector_names[grepl(paste0("^", cell), sector_names)]
       
-      if(!is.null(ident_names)){
-        cell_label <- ident_names[cell]
-      } else {
-        cell_label <- cell
-      }
-      
       if(length(row_pick)){
         highlight.sector(
           sector_names[grepl(paste0("^", cell, "-"), sector_names)],
           track.index = 1, col = cell_colors[[cell]],
-          text = cell_label,
+          text = cell,
           cex = 1, facing = "inside",
           text.col = "black", niceFacing = FALSE,
           text.vjust = -1.5

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -709,7 +709,7 @@ circos_ligand_receptor <-
                  annotationTrack = c("grid"),
                  preAllocateTracks = list(
                    track.height = mm_h(4),
-                   track.margin = c(mm_h(4), 0)),
+                   track.margin = c(mm_h(2), 0)),
                  big.gap = 2
     )
     
@@ -738,25 +738,24 @@ circos_ligand_receptor <-
       
       if(length(row_pick)){
         highlight.sector(
-          sector_names[grepl(paste0("^", cell), sector_names)], 
+          sector_names[grepl(paste0("^", cell), sector_names)],
           track.index = 1, col = cell_colors[[cell]],
           text = cell_label,
-          cex = 2.3, facing = "outside",
-          text.col = "black", niceFacing = TRUE,
-          text.vjust = 1.6
+          cex = 1, facing = "inside",
+          text.col = "black", niceFacing = FALSE,
+          text.vjust = -1.5
         )
       }
     }
-    
-    # highlight receptor sector
-    highlight.sector(
-      sector_names[grepl(paste0("^", receptor, "$"), sector_names)], 
-      track.index = 1, col = "#FFFFFF",
-      text = receptor, cex = 3.5, facing = "clockwise",
-      text.col = "black", niceFacing = TRUE,
-      pos = 4
-    )
-  }
+  # highlight receptor sector
+  highlight.sector(
+    sector_names[grepl(paste0("^", receptor, "$"), sector_names)], 
+    track.index = 1, col = "#FFFFFF",
+    text = receptor, cex = 3.5, facing = "clockwise",
+    text.col = "black", niceFacing = TRUE,
+    pos = 4
+  )
+}
 
 #' Normalize a matrix to its max value by row or column
 #' 

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -651,7 +651,10 @@ circos_ligand_receptor <-
     ligands <- dom@linkages$rec_lig[[receptor]]
     signaling_df <- NULL
     
-    cell_idents <- unique(dom@clusters)
+    if(is.null(cell_idents)){
+      # default to all cluster labels in domino object in alphabetical order
+      cell_idents <- sort(unique(dom@clusters))
+    }
     
     for(cell in cell_idents){
       cell_barcodes <- colnames(z_scores[,dom@clusters == cell])

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -725,9 +725,10 @@ circos_ligand_receptor <-
       if(signaling_df[signaling_df$origin == send,][["mean.expression"]] > ligand_expression_threshold){
         # TODO: have chords originate from the center of the arc 
         # c(0.5 - (expr/2), 0.5 + (expr/2))
+        expr <- signaling_df[signaling_df$origin == send,][["mean.expression"]]
         
         circos.link(send, 
-                    c(0, signaling_df[signaling_df$origin == send,][["mean.expression"]]), 
+                    c(0.5 - (expr/2), 0.5 + (expr/2)), 
                     receptor, 2,
                     col = paste0(grid_col[[send]], "88"))
       }

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -769,8 +769,8 @@ circos_ligand_receptor <-
   )
   lgd_list_vertical = packLegend(lgd_cells, lgd_ligands)
   draw(lgd_list_vertical, 
-       x = unit(1.05, "npc"), y = unit(0.9, "npc"),
-       just = c("right", "top"))
+       x = unit(1, "npc"), y = unit(0.5, "npc"),
+       just = c("right", "center"))
 }
 
 #' Normalize a matrix to its max value by row or column

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -671,6 +671,11 @@ circos_ligand_receptor <-
     # TODO: add arguent to pick ligands to plot, use this unique() result as default
     ligands <- unique(gsub(".*_", "", signaling_df[["origin"]]))
     
+    # exit function if no ligands are expressed above ligand expression threshold
+    if(sum(signaling_df[["mean.expression"]] > ligand_expression_threshold) == 0){
+      stop(paste0("No ligands of ", receptor, " exceed ligand expression threshold."))
+    }
+    
     # initialize chord diagram with even ligand arcs
     arc_df <- signaling_df[, c("origin", "destination")]
     arc_df["ligand.arc"] <- 1
@@ -679,7 +684,7 @@ circos_ligand_receptor <-
     
     # name grouping based on [cell_ident]
     nm <- c(receptor, arc_df$origin)
-    group <- structure(gsub("_.*", "", nm), names = nm)
+    group <- structure(c(nm[1], gsub("_.*", "", nm[-1])), names = nm)
     
     # order group as a factor with the receptor coming first
     group <- factor(group,
@@ -704,7 +709,6 @@ circos_ligand_receptor <-
                  rep(lig_colors, (nrow(signaling_df)/length(ligands)))
       ) 
     names(grid_col) <- c(receptor, signaling_df$origin)
-    # initiate pdf plotting device
     circos.clear()
     circos.par(start.degree = 0)
     
@@ -742,7 +746,7 @@ circos_ligand_receptor <-
       
       if(length(row_pick)){
         highlight.sector(
-          sector_names[grepl(paste0("^", cell), sector_names)],
+          sector_names[grepl(paste0("^", cell, "_"), sector_names)],
           track.index = 1, col = cell_colors[[cell]],
           text = cell_label,
           cex = 1, facing = "inside",

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -670,6 +670,10 @@ circos_ligand_receptor <-
     } else {stop(paste0("No clusters have active ", receptor, " signaling"))}
     
     signaling_df$mean.expression[is.na(signaling_df$mean.expression)] <- 0
+    # create a scaled mean expression plot for coord widths greater than 1
+    # by dividing by the max expression [range (0-1)]
+    # scaled.mean will only be used when the max expression is > 1
+    signaling_df$scaled.mean.expression <- signaling_df$mean.expression/max(signaling_df$mean.expression)
     
     # exit function if no ligands are expressed above ligand expression threshold
     if(sum(signaling_df[["mean.expression"]] > ligand_expression_threshold) == 0){
@@ -721,7 +725,11 @@ circos_ligand_receptor <-
     
     for(send in signaling_df$origin){
       if(signaling_df[signaling_df$origin == send,][["mean.expression"]] > ligand_expression_threshold){
-        expr <- signaling_df[signaling_df$origin == send,][["mean.expression"]]
+        if(max(signaling_df[["mean.expression"]]) > 1){
+          expr <- signaling_df[signaling_df$origin == send,][["scaled.mean.expression"]]
+        } else {
+          expr <- signaling_df[signaling_df$origin == send,][["mean.expression"]]
+        }
         
         circos.link(send, 
                     c(0.5 - (expr/2), 0.5 + (expr/2)), 
@@ -750,7 +758,7 @@ circos_ligand_receptor <-
   highlight.sector(
     sector_names[grepl(paste0("^", receptor, "$"), sector_names)], 
     track.index = 1, col = "#FFFFFF",
-    text = receptor, cex = 3.5, facing = "clockwise",
+    text = receptor, cex = 1.5, facing = "clockwise",
     text.col = "black", niceFacing = TRUE,
     pos = 4
   )

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -645,6 +645,7 @@ circos_ligand_receptor <-
     # ident_names: TODO debug argument to allow passing of [cell_ident] with \n to make long names more legible on the circos plot
     
     require(circlize)
+    require(ComplexHeatmap)
     
     z_scores <- dom@z_scores
     ligands <- dom@linkages$rec_lig[[receptor]]
@@ -755,6 +756,21 @@ circos_ligand_receptor <-
     text.col = "black", niceFacing = TRUE,
     pos = 4
   )
+  # create legends
+  lgd_cells = Legend(
+    at = as.character(cell_idents), type = "grid", 
+    legend_gp = gpar(fill = cell_colors),
+    title_position = "topleft", title = "cell identity"
+  )
+  lgd_ligands = Legend(
+    at = ligands, type = "grid", 
+    legend_gp = gpar(fill = lig_colors),
+    title_position = "topleft", title = "ligand"
+  )
+  lgd_list_vertical = packLegend(lgd_cells, lgd_ligands)
+  draw(lgd_list_vertical, 
+       x = unit(1.05, "npc"), y = unit(0.9, "npc"),
+       just = c("right", "top"))
 }
 
 #' Normalize a matrix to its max value by row or column

--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -140,6 +140,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
                 inc_ligs = unlist(inc_ligs_list)
             }
             
+            
             lig_genes = intersect(inc_ligs, rownames(dom@z_scores))
             if(length(lig_genes) == 1){lig_genes = numeric(0)}
             cl_sig_mat = matrix(0, ncol = length(levels(dom@clusters)), 


### PR DESCRIPTION
Corrects functionality for the circos plotting function for ligand expression targeting a specified receptor:
- calls circlize and complexheatmap as dependencies
- plots cell types from dom@clusters in alphabetical order with option for user specified cell types and ordering
- expression values called from cl_signaling_matrices to match other plotting functions and plot ligand complexes
- consideration provided for scaling mean ligand expression values greater than 1 to a 0-1 range to avoid chord overlaps
- removed hard-coded call of pdf() function for rendering the resulting plot
- coords originate from the center of ligand arcs
- enables user-specified colors for cell types
- renders a figure legend for the plotted cell types and for ligands of the plotted receptor