### PR TITLE
use ligands only in expression data and prevent null values in comple…

### DIFF
--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -12,30 +12,30 @@
 #' @export
 #' 
 build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01, 
-    max_rec_per_tf = 5, rec_tf_cor_threshold = .15,
-    min_rec_percentage = .1){
+                        max_rec_per_tf = 5, rec_tf_cor_threshold = .15,
+                        min_rec_percentage = .1){
     if(dom@misc[['create']] == FALSE){
         stop('Please run domino_create to create the domino object.')
     }
     dom@misc[['build']] = TRUE
     dom@misc[['build_vars']] = c(max_tf_per_clust = max_tf_per_clust, 
-        min_tf_pval = min_tf_pval, max_rec_per_tf = max_rec_per_tf, 
-        rec_tf_cor_threshold = rec_tf_cor_threshold,
-        min_rec_percentage = min_rec_percentage)
+                                 min_tf_pval = min_tf_pval, max_rec_per_tf = max_rec_per_tf, 
+                                 rec_tf_cor_threshold = rec_tf_cor_threshold,
+                                 min_rec_percentage = min_rec_percentage)
     
     if(length(dom@clusters)){
         # Get transcription factors for each cluster
         clust_tf = list()
         for(clust in levels(dom@clusters)){
             ordered = sort(dom@clust_de[,clust], decreasing = FALSE)
-
+            
             # If there are more ties than max tf per cluster then rank by logfc
             if(sum(ordered == 0) > max_tf_per_clust){
                 zeros = names(ordered)[which(ordered == 0)]
                 fcs = c()
                 for(zero in zeros){
                     fc = mean(dom@features[zero, which(dom@clusters == clust)]) - 
-                        mean(dom@features[zero, which(dom@clusters != clust)])
+                      mean(dom@features[zero, which(dom@clusters != clust)])
                     fcs = c(fcs, fc)
                 }
                 names(fcs) = zeros
@@ -43,27 +43,26 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             } else {
                 sorted = ordered[which(ordered < min_tf_pval)]
             }
-
+            
             if(length(sorted) > max_tf_per_clust){
                 sorted = sorted[1:max_tf_per_clust]
             }
-
+            
             clust_tf[[clust]] = names(sorted)
         }
         dom@linkages[['clust_tf']] = clust_tf
-
+        
         # Get receptors for each transcription factor
         tf_rec = list()
         for(tf in colnames(dom@cor)){
             ordered = sort(dom@cor[,tf], decreasing = TRUE)
             filtered = ordered[which(ordered > rec_tf_cor_threshold)]
-
+            
             if(length(filtered) > max_rec_per_tf){
                 top_receptors = names(filtered)[1:max_rec_per_tf]
             } else {
                 top_receptors = names(filtered)
             }
-            
             tf_rec[[tf]] = top_receptors
         }
         dom@linkages[['tf_rec']] = tf_rec
@@ -77,7 +76,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             if(rec %in% names(dom@linkages$complexes)){
               rec_gene = dom@linkages$complexes[[rec]]
             } else {rec_gene = rec}
-            
+        
             if(length(rec_gene) == sum(rec_gene %in% pass_genes)){
               expressed = c(expressed, rec)
             }
@@ -86,7 +85,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
           cl_tf_rec[[clust]] =
               lapply(dom@linkages$tf_rec[active_tf], 
                      FUN = function(x){return(x[x %in% expressed])}
-                     )
+              )
           }
         dom@linkages[['clust_tf_rec']] = cl_tf_rec
         
@@ -99,7 +98,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             clust_rec[[clust]] = vec
         }
         dom@linkages[['clust_rec']] = clust_rec
-
+        
         # Get a list of incoming ligands for each cluster
         clust_ligs = list()
         for(clust in levels(dom@clusters)){
@@ -109,11 +108,11 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
               clust_ligs[[clust]] = vec
         }
         dom@linkages[['clust_incoming_lig']] = clust_ligs
-
+        
         # Build signaling matrices for each cluster
         cl_signaling_matrices = list()
         signaling = matrix(0, ncol = length(levels(dom@clusters)), 
-            nrow = length(levels(dom@clusters)))
+                           nrow = length(levels(dom@clusters)))
         rownames(signaling) = paste0('R_', levels(dom@clusters))
         colnames(signaling) = paste0('L_', levels(dom@clusters))
         
@@ -121,12 +120,12 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             inc_ligs = clust_ligs[[clust]]
             rl_map = dom@misc[["rl_map"]]
             inc_ligs <- sapply(inc_ligs, function(l){
-               int <- rl_map[rl_map$L.name == l, ][1,] 
-               if((int$L.name != int$L.gene) & !grepl("\\,", int$L.gene)){
-                   int$L.gene
-               } else { 
-                   int$L.name
-               }
+              int <- rl_map[rl_map$L.name == l, ][1,] 
+              if((int$L.name != int$L.gene) & !grepl("\\,", int$L.gene)){
+                  int$L.gene
+              } else { 
+                  int$L.name
+              }
             })
             if(length(dom@linkages$complexes) > 0){ #if complexes were used
                 inc_ligs_list <- lapply(inc_ligs, function(l){
@@ -144,7 +143,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             lig_genes = intersect(inc_ligs, rownames(dom@z_scores))
             if(length(lig_genes) == 1){lig_genes = numeric(0)}
             cl_sig_mat = matrix(0, ncol = length(levels(dom@clusters)), 
-                nrow = length(lig_genes))
+                                nrow = length(lig_genes))
             colnames(cl_sig_mat) = colnames(signaling)
             rownames(cl_sig_mat) = lig_genes
             for(c2 in levels(dom@clusters)){
@@ -165,7 +164,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             }
             if(length(dom@linkages$complexes) > 0) { #if complexes were used
                 cl_sig_list <- lapply(seq_along(inc_ligs_list), function(x) {
-                    if (all(inc_ligs_list[[x]] %in% inc_ligs)) { #Some of the ligands in the list object may not be present in the data
+                    if (all(inc_ligs_list[[x]] %in% lig_genes)) { #Some of the ligands in the list object may not be present in the data
                         if (length(inc_ligs_list[[x]]) > 1) {
                             return(colMeans(cl_sig_mat[inc_ligs_list[[x]], ]))
                         } else {
@@ -174,29 +173,32 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
                     }
                 })
                 names(cl_sig_list) <- names(inc_ligs_list)
-                if(length(cl_sig_list)){cl_sig_mat <- do.call(rbind, cl_sig_list)}
+                if(length(cl_sig_list)>1){cl_sig_mat <- do.call(rbind, cl_sig_list)}
             }
+          
             cl_signaling_matrices[[clust]] = cl_sig_mat
-            signaling[paste0('R_', clust),] = colSums(cl_sig_mat)
+            if(nrow(cl_sig_mat) > 1){
+                signaling[paste0('R_', clust),] = colSums(cl_sig_mat)
+            } else {signaling[paste0('R_', clust),] = 0}
         }
         dom@cl_signaling_matrices = cl_signaling_matrices
         dom@signaling = signaling
     } else {
         # If clusters are not defined, take all TFs selected previously
         dom@linkages[['clust_tf']] = list('clust' = rownames(dom@features))
-
+        
         # ID receptors for transcription factors
         tf_rec = list()
         for(tf in colnames(dom@cor)){
             ordered = sort(dom@cor[,tf], decreasing = TRUE)
             filtered = ordered[which(ordered > rec_tf_cor_threshold)]
-
+            
             if(length(filtered) > max_rec_per_tf){
                 top_receptors = names(filtered)[1:max_rec_per_tf]
             } else {
                 top_receptors = names(filtered)
             }
-            
+          
             tf_rec[[tf]] = top_receptors
         }
         dom@linkages[['tf_rec']] = tf_rec


### PR DESCRIPTION
…x ligands

cl_signaling_matrix uses ligand gene names from the lig_genes variable that holds gene names also found within the z_scores matrix. When accounting for ligand complexes, rbind is only used if the signaling matrix has more than 1 row because rbind with fewer rows returns a null value. ColSums is also only used for signaling matrices with more than one row when aggregating the cluster signaling matrices to the total signaling matrix.