### PR TITLE
Jtm/bugfix/run without regulons

### DIFF
--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -417,7 +417,7 @@ create_domino = function(rl_map, features, ser = NULL, counts = NULL,
             tf = substring(module, first = 1, last = nchar(module) - 3)
             module_targets = tf_targets[[tf]]
             module_rec_targets = intersect(module_targets, ser_receptors)
-        }
+        } else {module_rec_targets = NULL}
         scores = dom@features[module,]
         rhorow = rep(0, length(ser_receptors))
         names(rhorow) = ser_receptors

--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -164,7 +164,7 @@ build_domino = function(dom, max_tf_per_clust = 5, min_tf_pval = .01,
             }
             if(length(dom@linkages$complexes) > 0) { #if complexes were used
                 cl_sig_list <- lapply(seq_along(inc_ligs_list), function(x) {
-                    if (all(inc_ligs_list[[x]] %in% inc_ligs)) { #Some of the ligands in the list object may not be present in the data
+                    if (all(inc_ligs_list[[x]] %in% lig_genes)) { #Some of the ligands in the list object may not be present in the data
                         if (length(inc_ligs_list[[x]]) > 1) {
                             return(colMeans(cl_sig_mat[inc_ligs_list[[x]], ]))
                         } else {


### PR DESCRIPTION
Enables create to be run without a regulons result for TF activity scoring methods besides scenic.