### PR TITLE
Jtm/regulons/unified list format

### DIFF
--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -438,7 +438,7 @@ create_domino = function(rl_map, features, ser = NULL, counts = NULL,
             print(paste0(cur, ' of ', n_tf))
         }
         if(!is.null(dom@linkages$tf_targets)){
-            tf = substring(module, first = 1, last = nchar(module) - 3)
+            tf = gsub(pattern = "\\.\\.\\.", replacement = "", module) # correction for AUC values from pySCENIC that append an elipses to TF names due to (+) characters in the orignial python output
             module_targets = tf_targets[[tf]]
             module_rec_targets = intersect(module_targets, ser_receptors)
         } else {module_rec_targets = NULL}


### PR DESCRIPTION
Regulons are now supplied to create_domino in a list format. Also corrects the precaution that receptor genes can never be correlated/linked to a tf which triggers the receptor's transcription (receptor in the TF's regulon).